### PR TITLE
Add AutoSave Example - Angular

### DIFF
--- a/pluginDefinition.json
+++ b/pluginDefinition.json
@@ -16,7 +16,8 @@
     "defaultWindowStyle": {
       "width": 850,
       "height": 450
-    }
+    },
+    "autosave": true
   },
   "dataServices": [
     {


### PR DESCRIPTION
This PR serves as an example of how to subscribe to an AutoSave Event by Zowe Desktop for an Angular Application

This example demonstrates how to save the `parameters` and `AppId` of Angular App: 

**1. Inject the Session Events token**
`    @Inject(Angular2InjectionTokens.SESSION_EVENTS) private sessionEvents: Angular2PluginSessionEvents`

**2. Subscribe to autosaveEmitter**
```
   this.autoSaveEvent = this.sessionEvents.autosaveEmitter.subscribe((saveThis: any)=> {
      if (saveThis) {
        saveThis({'appData':{'requestText':this.parameters,'targetAppId':this.targetAppId}});
      }
    });
```

**3. Receive saved data**
In order to receive the data, use `data.appData.requestText` and `data.appData.targetAppId` as seen in `handleLaunchOrMessageObject()` 

**Note:** 
1. _It is necessary to unsubscribe to the AutoSave Event when the component is destroyed_
2. _You must add an autosave property to pluginDefinition `"autosave": true`_

Signed-off-by: miteshgoplani miteshgoplani@gmail.com