### PR TITLE
 Automate changelog note

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -33,6 +33,50 @@ jobs:
           github-repo: ${{ github.repository }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  check_changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+            path: copy-repo
+            fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+
+      - name: Get changed files
+        id: changed-files
+        run: |
+            cd copy-repo
+            if ${{ github.event_name == 'pull_request' }}; then
+                echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
+            else
+                echo "changed_files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
+            fi
+
+      - name: List changed files
+        id: set-flag
+        run: |
+            cd copy-repo
+            for file in ${{ steps.changed-files.outputs.changed_files }}; do
+                echo "$file was changed"
+                if [[ $file == "CHANGELOG.md" ]]
+                then
+                  echo "file-flag=true" >> $GITHUB_OUTPUT
+                  break;
+                else
+                  echo "file-flag=false" >> $GITHUB_OUTPUT
+                fi
+            done
+
+      - name: Check if CHANGELOG is Updated and Abort if not updated
+        if: steps.set-flag.outputs.file-flag != 'true'
+        run: |
+          echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
+          exit 1
+
+      - name: Remove copy-repo
+        if: always()
+        run: rm -r copy-repo
+
   build:
     runs-on: ubuntu-latest
     needs: check-permission

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -34,6 +34,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   update-changelog:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       was_updated: ${{ steps.check-change.outputs.change_detected }}
@@ -109,6 +110,7 @@ jobs:
           fi
 
   check_changelog:
+    if: github.event_name == 'pull_request'
     needs: update-changelog
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -92,10 +92,10 @@ jobs:
               sed -i "$ANCHOR_LINE a\\
               \n## $VERSION\n- $ESCAPED_CHANGELOG (#${{ github.event.pull_request.number }})\n" CHANGELOG.md
             fi
-            git config --local user.email "action@github.com"
-            git config --local user.name "GitHub Action"
+            git config --global user.email "zowe-robot@users.noreply.github.com"
+            git config --global user.name "Zowe Robot"
             git add CHANGELOG.md
-            git commit -m "Update changelog with PR #${{ github.event.pull_request.number }} description"
+            git commit -s -m "Update changelog with PR #${{ github.event.pull_request.number }} description"
             git push
           fi
       - name: check for changes

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -56,80 +56,40 @@ jobs:
             echo "ERROR: CHANGELOG.md has not been updated."
             echo "::set-output name=check_commit::false"
           fi
-
       - name: Compare PR description with template
         if: steps.check-changelog.outputs.check_commit == 'false'
+        env:
+          PR_DESCRIPTION: ${{ github.event.pull_request.body }}
         run: |
-         PR_DESCRIPTION="${{ github.event.pull_request.body }}"
-         echo "$PR_DESCRIPTION" > /tmp/pr_description.txt
-         echo "PR DESCRIPTION saved to /tmp/pr_description.txt."
-         cat /tmp/pr_description.txt
-
-         # Save the template content to a file
-         TEMPLATE_CONTENT=$(sed 's/"//g' .github/pull_request_template.md)
-         echo "$TEMPLATE_CONTENT" > /tmp/template_content.txt
-         echo "Template content saved to /tmp/template_content.txt."
-         cat /tmp/template_content.txt
-
-         # Use diff to compare the two files
-         if diff -wB /tmp/pr_description.txt /tmp/template_content.txt > /dev/null; then
-           echo "ERROR: PR description is identical to the template."
-           exit 1
-         else
-           echo "PR description and template are different."
-         fi
-
-      - name: Extract changelog info
-        if: steps.check-changelog.outputs.check_commit == 'false'
-        id: extract-changelog
-        run: |
-          PR_DESCRIPTION=$(cat /tmp/pr_description.txt)
-          # Check if "changelog:" exists in PR description
-          if echo "$PR_DESCRIPTION" | grep -q "VERSION:" && echo "$PR_DESCRIPTION" | grep -q "CHANGELOG:"; then
-            # Extract content after "changelog:"
-            CHANGELOG_TEXT=$(echo $PR_DESCRIPTION | sed -n 's/.*CHANGELOG: \(.*\)/\1/p')
-
-            # Check if extracted CHANGELOG_TEXT is empty or identical to the template content
-            TEMPLATE_CONTENT=$(cat /tmp/template_content.txt)
-            if [ -z "$CHANGELOG_TEXT" ] || [ "$CHANGELOG_TEXT" == "$TEMPLATE_CONTENT" ]; then
-              echo "The changelog information after 'CHANGELOG:' cannot be empty or identical to pull_request_template.md."
-              exit 1
-            fi
-
-            # Extract VERSION: from PR description
-            VERSION=$(echo "$PR_DESCRIPTION" | grep -oP 'VERSION:\s*\K\d+\.\d+\.\d+')
-            echo "Extracted changelog: $CHANGELOG_TEXT"
-            echo "::set-output name=changelog::$CHANGELOG_TEXT"
-            echo "::set-output name=version::$VERSION"
-          else
-            echo -e "No changelog and version information found in PR description. Please add them.\nExpected Format:\nVERSION:vX.XX.X\nCHANGELOG:This is changelog note.\nTo re-run the action, just make a push or commit after updating the PR description or updating the changelog via a manual file changing commit."
+          # Safely print the PR description using Node.js
+          
+          node -e "const fs=require('fs'); fs.writeFileSync('/tmp/pr_description.txt', process.env.PR_DESCRIPTION);"
+          # Use diff to compare the two files
+          if diff -wB /tmp/pr_description.txt .github/pull_request_template.md > /dev/null; then
+            echo "ERROR: PR description is identical to the template."
             exit 1
+          else
+            echo "PR description and template are different."
           fi
 
       - name: Check PR body against changelog
         if: steps.check-changelog.outputs.check_commit == 'false'
+        id: extract-changelog
         run: |
-          ESCAPED_CHANGELOG="${{ steps.extract-changelog.outputs.changelog }}"
-          ESCAPED_CHANGELOG=$(echo "$ESCAPED_CHANGELOG" | sed "s/'/\\\\'/g")
-          VERSION="${{ steps.extract-changelog.outputs.version }}"
-
-          if ! grep -Fq "$ESCAPED_CHANGELOG" CHANGELOG.md; then
-            # Check if version exists in CHANGELOG.md
-            if grep -q "^## $VERSION" CHANGELOG.md; then
-              # Append PR description to existing version
-              sed -i "/^## $VERSION/a - $ESCAPED_CHANGELOG (#${{ github.event.pull_request.number }})" CHANGELOG.md
-            else
-              # Append new version and PR description
-              ANCHOR_LINE=$(awk '/All notable changes to the sample angular app will be documented in this file\./ {print NR}' CHANGELOG.md)
-              sed -i "$ANCHOR_LINE a\\
-              \n## $VERSION\n- $ESCAPED_CHANGELOG (#${{ github.event.pull_request.number }})\n" CHANGELOG.md
-            fi
+          result=$(node .github/workflows/set-changelog.js ${{ github.event.pull_request.number }})
+          if [ "$result" = "Success" ]; then
             git config --global user.email "zowe-robot@users.noreply.github.com"
             git config --global user.name "Zowe Robot"
             git add CHANGELOG.md
             git commit -s -m "Update changelog with PR #${{ github.event.pull_request.number }} description"
             git push
+            echo "Updated CHANGELOG from description"
+          else
+            echo $result
+            echo -e "No changelog and version information found in PR description. Please add them.\nExpected Format:\nVERSION:X.XX.X\nCHANGELOG:This is changelog note.\nTo re-run the action, just make a push or commit after updating the PR description or updating the changelog via a manual file changing commit."
+            exit 1
           fi
+
       - name: check for changes
         id: check-change
         run: |
@@ -138,7 +98,7 @@ jobs:
             echo "::set-output name=change_detected::false"
           else
             echo "::set-output name=change_detected::true"
-          fi
+            fi
 
   check_changelog:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -197,15 +197,6 @@ jobs:
           publish-registry-email: ${{ secrets.NPM_PRIVATE_REGISTRY_EMAIL }}
           publish-registry-username: ${{ secrets.NPM_PRIVATE_REGISTRY_USERNAME }}
           publish-registry-password: ${{ secrets.NPM_PRIVATE_REGISTRY_PASSWORD }}
-<<<<<<< HEAD
-
-      - name: '[Prep 11] Bump Staging Version '
-        if: ${{ github.event.inputs.PERFORM_RELEASE == 'true' && env.RELEASE == 'true' }}
-        uses: zowe-actions/zlux-builds/plugins/bump-version@v2.x/main
-        env:
-         GITHUB_TOKEN: ${{ secrets.ZOWE_ROBOT_TOKEN }}
-=======
->>>>>>> b2833837d4f60b4fcbf8bc4b2539f3ccc8761a08
 
       - name: '[Prep 11] Publish NPM Package  '
         if: ${{ github.event.inputs.PERFORM_RELEASE == 'true' && env.RELEASE == 'true' }}

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -56,25 +56,56 @@ jobs:
             echo "ERROR: CHANGELOG.md has not been updated."
             echo "::set-output name=check_commit::false"
           fi
+
+      - name: Compare PR description with template
+        if: steps.check-changelog.outputs.check_commit == 'false'
+        run: |
+         PR_DESCRIPTION="${{ github.event.pull_request.body }}"
+         echo "$PR_DESCRIPTION" > /tmp/pr_description.txt
+         echo "PR DESCRIPTION saved to /tmp/pr_description.txt."
+         cat /tmp/pr_description.txt
+
+         # Save the template content to a file
+         TEMPLATE_CONTENT=$(sed 's/"//g' .github/pull_request_template.md)
+         echo "$TEMPLATE_CONTENT" > /tmp/template_content.txt
+         echo "Template content saved to /tmp/template_content.txt."
+         cat /tmp/template_content.txt
+
+         # Use diff to compare the two files
+         if diff -wB /tmp/pr_description.txt /tmp/template_content.txt > /dev/null; then
+           echo "ERROR: PR description is identical to the template."
+           exit 1
+         else
+           echo "PR description and template are different."
+         fi
+
       - name: Extract changelog info
         if: steps.check-changelog.outputs.check_commit == 'false'
         id: extract-changelog
         run: |
-          PR_DESCRIPTION="${{ github.event.pull_request.body }}"
+          PR_DESCRIPTION=$(cat /tmp/pr_description.txt)
           # Check if "changelog:" exists in PR description
           if echo "$PR_DESCRIPTION" | grep -q "VERSION:" && echo "$PR_DESCRIPTION" | grep -q "CHANGELOG:"; then
-            # Extract text after "changelog:"
+            # Extract content after "changelog:"
             CHANGELOG_TEXT=$(echo $PR_DESCRIPTION | sed -n 's/.*CHANGELOG: \(.*\)/\1/p')
+
+            # Check if extracted CHANGELOG_TEXT is empty or identical to the template content
+            TEMPLATE_CONTENT=$(cat /tmp/template_content.txt)
+            if [ -z "$CHANGELOG_TEXT" ] || [ "$CHANGELOG_TEXT" == "$TEMPLATE_CONTENT" ]; then
+              echo "The changelog information after 'CHANGELOG:' cannot be empty or identical to pull_request_template.md."
+              exit 1
+            fi
+
             # Extract VERSION: from PR description
             VERSION=$(echo "$PR_DESCRIPTION" | grep -oP 'VERSION:\s*\K\d+\.\d+\.\d+')
             echo "Extracted changelog: $CHANGELOG_TEXT"
             echo "::set-output name=changelog::$CHANGELOG_TEXT"
             echo "::set-output name=version::$VERSION"
           else
-            echo -e "No changelog and version information found in PR description please add them.\n Expected Format:\n VERSION:X.XX.X\n CHANGELOG:This is changelog note.\n
-            To re-run the action, just make a push or commit after updating the PR description or updating the changelog via a manual file changing commit."
+            echo -e "No changelog and version information found in PR description. Please add them.\nExpected Format:\nVERSION:vX.XX.X\nCHANGELOG:This is changelog note.\nTo re-run the action, just make a push or commit after updating the PR description or updating the changelog via a manual file changing commit."
             exit 1
           fi
+
       - name: Check PR body against changelog
         if: steps.check-changelog.outputs.check_commit == 'false'
         run: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, reopened, synchronize]
 
   workflow_dispatch:
-    inputs: 
+    inputs:
       BRANCH_NAME:
         description: 'Specify branch name or PR (e.g. PR-41)'
         required: false
@@ -20,7 +20,7 @@ on:
         type: boolean
         description: 'Perform release, Defauls is false'
         required: false
-      
+
 jobs:
   check-permission:
     runs-on: ubuntu-latest
@@ -33,49 +33,96 @@ jobs:
           github-repo: ${{ github.repository }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+  update-changelog:
+    runs-on: ubuntu-latest
+    outputs:
+      was_updated: ${{ steps.check-change.outputs.change_detected }}
+      check_commit: ${{ steps.check-changelog.outputs.check_commit }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Check for updated CHANGELOG.md using git
+        id: check-changelog
+        run: |
+          if git diff --name-only origin/${{ github.base_ref }} | grep -q "^CHANGELOG.md$"; then
+            echo "CHANGELOG.md has been updated."
+            echo "::set-output name=check_commit::true"
+          else
+            echo "ERROR: CHANGELOG.md has not been updated."
+            echo "::set-output name=check_commit::false"
+          fi
+      - name: Extract changelog info
+        if: steps.check-changelog.outputs.check_commit == 'false'
+        id: extract-changelog
+        run: |
+          PR_DESCRIPTION="${{ github.event.pull_request.body }}"
+          # Check if "changelog:" exists in PR description
+          if echo "$PR_DESCRIPTION" | grep -q "VERSION:" && echo "$PR_DESCRIPTION" | grep -q "CHANGELOG:"; then
+            # Extract text after "changelog:"
+            CHANGELOG_TEXT=$(echo $PR_DESCRIPTION | sed -n 's/.*CHANGELOG: \(.*\)/\1/p')
+            # Extract VERSION: from PR description
+            VERSION=$(echo "$PR_DESCRIPTION" | grep -oP 'VERSION:\s*\K\d+\.\d+\.\d+')
+            echo "Extracted changelog: $CHANGELOG_TEXT"
+            echo "::set-output name=changelog::$CHANGELOG_TEXT"
+            echo "::set-output name=version::$VERSION"
+          else
+            echo -e "No changelog and version information found in PR description please add them.\n Expected Format:\n VERSION:X.XX.X\n CHANGELOG:This is changelog note.\n
+            To re-run the action, just make a push or commit after updating the PR description or updating the changelog via a manual file changing commit."
+            exit 1
+          fi
+      - name: Check PR body against changelog
+        if: steps.check-changelog.outputs.check_commit == 'false'
+        run: |
+          ESCAPED_CHANGELOG="${{ steps.extract-changelog.outputs.changelog }}"
+          ESCAPED_CHANGELOG=$(echo "$ESCAPED_CHANGELOG" | sed "s/'/\\\\'/g")
+          VERSION="${{ steps.extract-changelog.outputs.version }}"
+
+          if ! grep -Fq "$ESCAPED_CHANGELOG" CHANGELOG.md; then
+            # Check if version exists in CHANGELOG.md
+            if grep -q "^## $VERSION" CHANGELOG.md; then
+              # Append PR description to existing version
+              sed -i "/^## $VERSION/a - $ESCAPED_CHANGELOG (#${{ github.event.pull_request.number }})" CHANGELOG.md
+            else
+              # Append new version and PR description
+              ANCHOR_LINE=$(awk '/All notable changes to the sample angular app will be documented in this file\./ {print NR}' CHANGELOG.md)
+              sed -i "$ANCHOR_LINE a\\
+              \n## $VERSION\n- $ESCAPED_CHANGELOG (#${{ github.event.pull_request.number }})\n" CHANGELOG.md
+            fi
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            git add CHANGELOG.md
+            git commit -m "Update changelog with PR #${{ github.event.pull_request.number }} description"
+            git push
+          fi
+      - name: check for changes
+        id: check-change
+        run: |
+          if git diff --name-only HEAD^ HEAD | grep 'changelog.md'; then
+            echo "No Changes detected, setting flag to false"
+            echo "::set-output name=change_detected::false"
+          else
+            echo "::set-output name=change_detected::true"
+          fi
+
   check_changelog:
+    needs: update-changelog
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-            path: copy-repo
-            fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+        uses: actions/checkout@v2
 
-      - name: Get changed files
-        id: changed-files
+      - name: Verify Changelog update
         run: |
-            cd copy-repo
-            if ${{ github.event_name == 'pull_request' }}; then
-                echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
-            else
-                echo "changed_files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
-            fi
-
-      - name: List changed files
-        id: set-flag
-        run: |
-            cd copy-repo
-            for file in ${{ steps.changed-files.outputs.changed_files }}; do
-                echo "$file was changed"
-                if [[ $file == "CHANGELOG.md" ]]
-                then
-                  echo "file-flag=true" >> $GITHUB_OUTPUT
-                  break;
-                else
-                  echo "file-flag=false" >> $GITHUB_OUTPUT
-                fi
-            done
-
-      - name: Check if CHANGELOG is Updated and Abort if not updated
-        if: steps.set-flag.outputs.file-flag != 'true'
-        run: |
-          echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
-          exit 1
-
-      - name: Remove copy-repo
-        if: always()
-        run: rm -r copy-repo
+          if [ "${{ needs.update-changelog.outputs.was_updated }}" != "true" ]; then
+            echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
+            exit 1
+          else
+            echo "changelog was updated successfully."
+          fi
 
   build:
     runs-on: ubuntu-latest
@@ -142,11 +189,11 @@ jobs:
           publish-registry-email: ${{ secrets.NPM_PRIVATE_REGISTRY_EMAIL }}
           publish-registry-username: ${{ secrets.NPM_PRIVATE_REGISTRY_USERNAME }}
           publish-registry-password: ${{ secrets.NPM_PRIVATE_REGISTRY_PASSWORD }}
-          
+
       - name: '[Prep 11] Bump Staging Version '
         if: ${{ github.event.inputs.PERFORM_RELEASE == 'true' && env.RELEASE == 'true' }}
         uses: zowe-actions/zlux-builds/plugins/bump-version@v2.x/main
-        env: 
+        env:
          GITHUB_TOKEN: ${{ secrets.ZOWE_ROBOT_TOKEN }}
 
       - name: '[Prep 10] Publish NPM Package  '

--- a/.github/workflows/set-changelog.js
+++ b/.github/workflows/set-changelog.js
@@ -1,0 +1,59 @@
+/*
+This program and the accompanying materials are
+made available under the terms of the Eclipse Public License v2.0 which accompanies
+this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+SPDX-License-Identifier: EPL-2.0
+
+Copyright Contributors to the Zowe Project.
+*/
+
+const fs = require('fs');
+
+// Must run with args: PR_NUMBER
+const PR_NUMBER = process.argv[2];
+const description = fs.readFileSync('/tmp/pr_description.txt', 'utf8');
+let changelogMsg, version;
+
+if (description.includes('VERSION:') && description.includes('CHANGELOG:')) {
+  let lines = description.split('\n');
+  lines.forEach((line) => {
+    if (line.startsWith('CHANGELOG:')) {
+      changelogMsg = line.substring('CHANGELOG:'.length).trim();
+    } else if (line.startsWith('VERSION:')) {
+      version = line.substring('VERSION:'.length).trim();
+    }
+  });
+
+  if (changelogMsg && version) {
+    let changelog = fs.readFileSync('CHANGELOG.md', 'utf8');
+    let changelogLines = changelog.split('\n');
+    let versionIndex = -1;
+    let anchorIndex = 0;
+    for (let i = 0; i < changelogLines.length; i++) {
+      if (changelogLines[i].includes('All notable changes to the sample angular app will be documented in this file.')) {
+        anchorIndex = i;
+      } else if (changelogLines[i].startsWith('## ' + version)) {  // Removed "v" prefix
+        versionIndex = i;
+        break;
+      }
+    }
+    if (versionIndex != -1) {
+      changelogLines.splice(versionIndex + 2, 0, `- ${changelogMsg} (#${PR_NUMBER})`);
+    } else {
+      changelogLines.splice(anchorIndex + 1, 0, `\n## ${version}\n- ${changelogMsg} (#${PR_NUMBER})`);
+    }
+    const newChangelog = changelogLines.join('\n');
+    fs.writeFileSync('CHANGELOG.md', newChangelog);
+    console.log('Success');
+  } else {
+    if (!changelogMsg) {
+      console.log('Missing CHANGELOG');
+    }
+    if (!version) {
+      console.log('Missing VERSION');
+    }
+  }
+} else {
+  console.log('Missing CHANGELOG or VERSION');
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the sample angular app will be documented in this file.
 
 ## 2.0.1
 
+- This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not. (#116)
 - Bugfix: Schema file was not included, preventing installation as a component
 - Bugfix: Manifest build content template was never resolved, so it has been removed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 All notable changes to the sample angular app will be documented in this file.
 
 ## 2.0.1
-
-- This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not. (#116)
 - Bugfix: Schema file was not included, preventing installation as a component
 - Bugfix: Manifest build content template was never resolved, so it has been removed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to the sample angular app will be documented in this file.
 
 ## 2.0.1
 
-- This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not. (#116)
 - Bugfix: Schema file was not included, preventing installation as a component
 - Bugfix: Manifest build content template was never resolved, so it has been removed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 All notable changes to the sample angular app will be documented in this file.
 
 ## 2.0.1
-- This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not. (#116)
 
 - Bugfix: Schema file was not included, preventing installation as a component
 - Bugfix: Manifest build content template was never resolved, so it has been removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the sample angular app will be documented in this file.
 
 ## 2.0.1
+- This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not. (#116)
 
 - Bugfix: Schema file was not included, preventing installation as a component
 - Bugfix: Manifest build content template was never resolved, so it has been removed.


### PR DESCRIPTION
VERSION: 2.0.1
CHANGELOG: This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not.