### PR TITLE
update workflow actions

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -141,7 +141,7 @@ jobs:
           node-version: 16.15.0
 
       - name: '[Prep 4] Setup jFrog CLI'
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@v2
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -138,7 +138,7 @@ jobs:
       - name: '[Prep 3] Setup Node'
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 16.15.0
 
       - name: '[Prep 4] Setup jFrog CLI'
         uses: jfrog/setup-jfrog-cli@v4

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: '[Prep 2] Cache node modules'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: |
@@ -136,12 +136,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-cache-node-modules-
       - name: '[Prep 3] Setup Node'
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.15.0
+          node-version: 20
 
       - name: '[Prep 4] Setup jFrog CLI'
-        uses: jfrog/setup-jfrog-cli@v2
+        uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_ARTIFACTORY_1: ${{ secrets.JF_ARTIFACTORY_TOKEN }}
 

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -138,7 +138,7 @@ jobs:
       - name: '[Prep 3] Setup Node'
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 18
 
       - name: '[Prep 4] Setup jFrog CLI'
         uses: jfrog/setup-jfrog-cli@v4


### PR DESCRIPTION
The github actions are automatically failing because it uses a deprecated version of both  `actions/cache@v2` `actions/setup-node@v2`. I have upgraded both to version 4. 