### PR TITLE
add build info section in manifest (port changes from PR #126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the sample angular app will be documented in this file.
 
+## 2.0.2
+- Bugfix: Generate build information in manifest.
+
 ## 2.0.1
 - Bugfix: Schema file was not included, preventing installation as a component
 - Bugfix: Manifest build content template was never resolved, so it has been removed.

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -18,6 +18,11 @@ license: EPL-2.0
 repository:
   type: git
   url: https://github.com/zowe/sample-angular-app.git
+build:
+  branch: "{{build.branch}}"
+  number: "{{build.number}}"
+  commitHash: "{{build.commitHash}}"
+  timestamp: "{{build.timestamp}}"
 # we do not specify encoding here because its already tagged ascii
 appfwPlugins:
   - path: .


### PR DESCRIPTION
Port changes from PR #126 for v2.x/staging

> The fix enables the zowe-actions/zlux-builds/plugins/prepare-workflow to generate build information in the manifest.yaml.